### PR TITLE
Add withHead macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,55 +62,48 @@ Many pages can define their metadata directly on the route, especially semi-stat
 ### Routes & Groups
 
 ```php
-use Laravel\Head\Facades\Head;
-
 Route::view('/contact', 'contact')
     ->name('contact')
-    ->metadata(Head::forMetadata(
+    ->withHead(
         title: 'Contact Us',
         description: 'Get in touch.',
-    ));
+    );
 ```
 
-Shared route metadata can be applied to a group:
+Shared route metadata can be applied to a group, at any position in the chain:
 
 ```php
-use Laravel\Head\Facades\Head;
-
-Route::metadata(Head::forMetadata(robots: 'noindex, nofollow'))
+Route::withHead(robots: 'noindex, nofollow')
     ->prefix('admin')
     ->name('admin.')
     ->group(function () {
         Route::get('/dashboard', DashboardController::class)
             ->name('dashboard')
-            ->metadata(Head::forMetadata(title: 'Dashboard'));
+            ->withHead(title: 'Dashboard');
     });
 ```
 
 Resource and singleton routes can define metadata too:
 
 ```php
-use Laravel\Head\Facades\Head;
-
-Route::resource('posts', PostController::class)->metadata(Head::forMetadata(
+Route::resource('posts', PostController::class)->withHead(
     robots: 'index, follow',
-));
+);
 
-Route::singleton('profile', ProfileController::class)->metadata(Head::forMetadata(
+Route::singleton('profile', ProfileController::class)->withHead(
     title: 'Your Profile',
-));
+);
 ```
 
-`Head::forMetadata()` returns a plain array for Laravel's native route metadata API, so route metadata remains compatible with cached routes.
+`withHead()` stores plain arrays through Laravel's native route metadata API, equivalent to calling `->metadata()` with the attributes nested under a `head` key, so route metadata remains compatible with cached routes.
 
-The top-level arguments are intentionally limited to Laravel Head's built-in route properties so editors and static analysis can catch misspelled names. Route attributes registered by custom tag builders may be passed through `extensions`:
+The named arguments are intentionally limited to Laravel Head's built-in route properties so editors and static analysis can catch misspelled names. Route attributes registered by custom tag builders may be passed through `extensions`:
 
 ```php
-Route::get('/article', ArticleController::class)
-    ->metadata(Head::forMetadata(
-        title: 'Article',
-        extensions: ['readingTime' => 4],
-    ));
+Route::get('/article', ArticleController::class)->withHead(
+    title: 'Article',
+    extensions: ['readingTime' => 4],
+);
 ```
 
 ### Supported Properties
@@ -327,11 +320,9 @@ Head::themeColor('#ffffff', media: Media::Light)
 Route metadata supports simple theme colors through the same camel-case key:
 
 ```php
-use Laravel\Head\Facades\Head;
-
-Route::view('/dashboard', 'dashboard')->metadata(Head::forMetadata(
+Route::view('/dashboard', 'dashboard')->withHead(
     themeColor: '#0f172a',
-));
+);
 ```
 
 ## App Metadata & Icons
@@ -364,9 +355,8 @@ Route metadata uses the same names:
 ```php
 use Laravel\Head\Enums\ImageType;
 use Laravel\Head\Enums\Media;
-use Laravel\Head\Facades\Head;
 
-Route::view('/dashboard', 'dashboard')->metadata(Head::forMetadata(
+Route::view('/dashboard', 'dashboard')->withHead(
     applicationName: 'Acme',
     colorScheme: 'light dark',
     appleWebAppTitle: 'Acme',
@@ -379,7 +369,7 @@ Route::view('/dashboard', 'dashboard')->metadata(Head::forMetadata(
     appleTouchIcon: ['href' => '/apple-touch-icon.png', 'sizes' => '180x180'],
     appleTouchStartupImage: ['href' => '/launch.png', 'media' => Media::Portrait],
     manifest: '/site.webmanifest',
-));
+);
 ```
 
 ## Progressive Web Apps
@@ -518,7 +508,7 @@ Schema::breadcrumbs()
 
 ### FAQs
 
-FAQ questions follow the same pattern — add them one at a time with `question()` or in bulk with `questions()`:
+FAQ questions follow the same pattern. Add them one at a time with `question()` or in bulk with `questions()`:
 
 ```php
 Head::schema(

--- a/_ide_helper.php
+++ b/_ide_helper.php
@@ -1,0 +1,456 @@
+<?php
+
+/**
+ * Editor helper declarations for the withHead() route macros registered by
+ * laravel/head. This file is never autoloaded or executed; editors such as
+ * VS Code with Intelephense index it so withHead() autocompletes on Laravel's
+ * routing classes. Keep the signatures in sync with the macros registered
+ * by \Laravel\Head\Routing\HeadRouteMacros.
+ *
+ * @see \Laravel\Head\Routing\HeadRouteMacros
+ */
+
+namespace Illuminate\Routing {
+    use Laravel\Head\Enums\RobotsRule;
+
+    class Router
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): RouteRegistrar {}
+    }
+}
+
+namespace Illuminate\Routing {
+    use Laravel\Head\Enums\RobotsRule;
+
+    class RouteRegistrar
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): RouteRegistrar {}
+    }
+}
+
+namespace Illuminate\Routing {
+    use Laravel\Head\Enums\RobotsRule;
+
+    class Route
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): Route {}
+    }
+}
+
+namespace Illuminate\Routing {
+    use Laravel\Head\Enums\RobotsRule;
+
+    class PendingResourceRegistration
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): PendingResourceRegistration {}
+    }
+}
+
+namespace Illuminate\Routing {
+    use Laravel\Head\Enums\RobotsRule;
+
+    class PendingSingletonResourceRegistration
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): PendingSingletonResourceRegistration {}
+    }
+}
+
+namespace Illuminate\Support\Facades {
+    use Illuminate\Routing\RouteRegistrar;
+    use Laravel\Head\Enums\RobotsRule;
+
+    class Route
+    {
+        /**
+         * Define head metadata for the route, stored through Laravel's native
+         * route metadata API. Provided by laravel/head.
+         *
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        public static function withHead(
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): RouteRegistrar {}
+    }
+}

--- a/src/Facades/Head.php
+++ b/src/Facades/Head.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Head\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Laravel\Head\Enums\RobotsRule;
 use Laravel\Head\HeadManager;
-use Laravel\Head\Routing\RouteAttributeParser;
 
 /**
  * @method static \Laravel\Head\HeadManager inertiaGlobals(callable(\Laravel\Head\HeadBuilder): mixed $callback)
@@ -73,119 +71,6 @@ use Laravel\Head\Routing\RouteAttributeParser;
  */
 class Head extends Facade
 {
-    /**
-     * Create cache-friendly Laravel route metadata for document head data.
-     *
-     * @param  array<mixed, mixed>|string|null  $title
-     * @param  array<mixed, mixed>|string|true|null  $canonical
-     * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
-     * @param  array<string, mixed>|null  $og
-     * @param  array<mixed, mixed>|string|null  $ogImage
-     * @param  array<mixed, mixed>|string|null  $ogVideo
-     * @param  array<mixed, mixed>|string|null  $ogAudio
-     * @param  array<string, mixed>|null  $twitter
-     * @param  array<mixed, mixed>|string|null  $twitterImage
-     * @param  array<mixed, mixed>|string|null  $preload
-     * @param  array<mixed, mixed>|string|null  $prefetch
-     * @param  array<mixed, mixed>|string|null  $preconnect
-     * @param  array<mixed, mixed>|string|null  $dnsPrefetch
-     * @param  array<string, string>|null  $alternates
-     * @param  array<mixed, mixed>|string|null  $feed
-     * @param  array<mixed, mixed>|string|null  $icon
-     * @param  array<mixed, mixed>|string|null  $favicon
-     * @param  array<mixed, mixed>|string|null  $appleTouchIcon
-     * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
-     * @param  array<mixed, mixed>|string|null  $maskIcon
-     * @param  array<mixed, mixed>|string|null  $manifest
-     * @param  array<mixed, mixed>|null  $schema
-     * @param  array<mixed, mixed>|null  $meta
-     * @param  array<mixed, mixed>|null  $link
-     * @param  array<string, mixed>  $extensions
-     * @return array<string, array<string, array<string, mixed>>>
-     */
-    public static function forMetadata(
-        string|array|null $title = null,
-        ?string $description = null,
-        string|array|true|null $canonical = null,
-        string|RobotsRule|array|null $robots = null,
-        ?string $themeColor = null,
-        ?string $applicationName = null,
-        ?string $colorScheme = null,
-        ?string $referrer = null,
-        ?string $viewport = null,
-        ?string $appleWebAppTitle = null,
-        ?bool $webAppCapable = null,
-        ?string $appleWebAppStatusBarStyle = null,
-        ?array $og = null,
-        string|array|null $ogImage = null,
-        string|array|null $ogVideo = null,
-        string|array|null $ogAudio = null,
-        ?array $twitter = null,
-        string|array|null $twitterImage = null,
-        string|array|null $preload = null,
-        string|array|null $prefetch = null,
-        string|array|null $preconnect = null,
-        string|array|null $dnsPrefetch = null,
-        ?array $alternates = null,
-        string|array|null $feed = null,
-        string|array|null $icon = null,
-        string|array|null $favicon = null,
-        string|array|null $appleTouchIcon = null,
-        string|array|null $appleTouchStartupImage = null,
-        string|array|null $maskIcon = null,
-        string|array|null $manifest = null,
-        ?array $schema = null,
-        ?array $meta = null,
-        ?array $link = null,
-        array $extensions = [],
-    ): array {
-        $values = [
-            'title' => $title,
-            'description' => $description,
-            'canonical' => $canonical,
-            'robots' => $robots,
-            'themeColor' => $themeColor,
-            'applicationName' => $applicationName,
-            'colorScheme' => $colorScheme,
-            'referrer' => $referrer,
-            'viewport' => $viewport,
-            'appleWebAppTitle' => $appleWebAppTitle,
-            'webAppCapable' => $webAppCapable,
-            'appleWebAppStatusBarStyle' => $appleWebAppStatusBarStyle,
-            'og' => $og,
-            'ogImage' => $ogImage,
-            'ogVideo' => $ogVideo,
-            'ogAudio' => $ogAudio,
-            'twitter' => $twitter,
-            'twitterImage' => $twitterImage,
-            'preload' => $preload,
-            'prefetch' => $prefetch,
-            'preconnect' => $preconnect,
-            'dnsPrefetch' => $dnsPrefetch,
-            'alternates' => $alternates,
-            'feed' => $feed,
-            'icon' => $icon,
-            'favicon' => $favicon,
-            'appleTouchIcon' => $appleTouchIcon,
-            'appleTouchStartupImage' => $appleTouchStartupImage,
-            'maskIcon' => $maskIcon,
-            'manifest' => $manifest,
-            'schema' => $schema,
-            'meta' => $meta,
-            'link' => $link,
-        ] + $extensions;
-
-        $attributes = [];
-
-        foreach ($values as $key => $value) {
-            if (! is_null($value)) {
-                $attributes[$key] = $value;
-            }
-        }
-
-        return RouteAttributeParser::metadata($attributes);
-    }
-
     /**
      * Get the registered name of the component.
      */

--- a/src/HeadServiceProvider.php
+++ b/src/HeadServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Inertia\Inertia;
 use Laravel\Head\Rendering\HeadRenderer;
+use Laravel\Head\Routing\HeadRouteMacros;
 use Laravel\Head\Schema\SchemaFactory;
 use Laravel\Head\Schema\SchemaValidator;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -49,6 +50,8 @@ class HeadServiceProvider extends ServiceProvider
             ? "<?php echo app('head')->renderForView(get_defined_vars()); ?>"
             : "<?php echo app('head')->renderForView(get_defined_vars(), {$expression}); ?>"
         );
+
+        (new HeadRouteMacros)->register();
 
         $this->registerExceptionStatusResolver();
         $this->shareWithInertia();

--- a/src/Routing/HeadRouteMacros.php
+++ b/src/Routing/HeadRouteMacros.php
@@ -1,0 +1,461 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Routing;
+
+use Closure;
+use Illuminate\Routing\PendingResourceRegistration;
+use Illuminate\Routing\PendingSingletonResourceRegistration;
+use Illuminate\Routing\Route;
+use Illuminate\Routing\Router;
+use Illuminate\Routing\RouteRegistrar;
+use Laravel\Head\Enums\RobotsRule;
+
+/**
+ * Registers the withHead() route macros.
+ *
+ * Each macro carries the full named-argument signature for the built-in
+ * route attributes so editors and static analysis can validate attribute
+ * names at every chain position; keep the five signatures and _ide_helper.php
+ * in sync when adding route attributes. The macros delegate to Laravel's
+ * native route metadata API immediately, so routes keep storing plain,
+ * cache-friendly arrays.
+ */
+class HeadRouteMacros
+{
+    /**
+     * Register the withHead() macro on every routing surface.
+     */
+    public function register(): void
+    {
+        Router::macro('withHead', $this->routerMacro());
+        RouteRegistrar::macro('withHead', $this->registrarMacro());
+        Route::macro('withHead', $this->routeMacro());
+        PendingResourceRegistration::macro('withHead', $this->pendingResourceMacro());
+        PendingSingletonResourceRegistration::macro('withHead', $this->pendingSingletonMacro());
+    }
+
+    /**
+     * Recover the typed routing object a macro closure was bound to.
+     *
+     * Macroable rebinds each macro closure at call time, so inside the
+     * closure $this is the routing object rather than this registrar.
+     *
+     * @template TScope of object
+     *
+     * @param  class-string<TScope>  $scope
+     * @return TScope
+     */
+    public static function bound(mixed $context, string $scope): object
+    {
+        assert($context instanceof $scope);
+
+        return $context;
+    }
+
+    /**
+     * Create the withHead() macro for group-position calls on the router,
+     * such as Route::withHead(...)->prefix('admin')->group(...).
+     */
+    protected function routerMacro(): Closure
+    {
+        /**
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        $macro = function (
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): RouteRegistrar {
+            $arguments = get_defined_vars();
+
+            $router = HeadRouteMacros::bound($this, Router::class);
+
+            return (new RouteRegistrar($router))->metadata(
+                RouteAttributeParser::metadataFromArguments($arguments)
+            );
+        };
+
+        return $macro;
+    }
+
+    /**
+     * Create the withHead() macro for chained group-position calls, such as
+     * Route::prefix('admin')->withHead(...)->group(...).
+     */
+    protected function registrarMacro(): Closure
+    {
+        /**
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        $macro = function (
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): RouteRegistrar {
+            $arguments = get_defined_vars();
+
+            $registrar = HeadRouteMacros::bound($this, RouteRegistrar::class);
+
+            return $registrar->metadata(
+                RouteAttributeParser::metadataFromArguments($arguments)
+            );
+        };
+
+        return $macro;
+    }
+
+    /**
+     * Create the withHead() macro for individual routes, such as
+     * Route::view('/dashboard', 'dashboard')->withHead(...).
+     */
+    protected function routeMacro(): Closure
+    {
+        /**
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        $macro = function (
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): Route {
+            $arguments = get_defined_vars();
+
+            $route = HeadRouteMacros::bound($this, Route::class);
+
+            return $route->metadata(
+                RouteAttributeParser::metadataFromArguments($arguments)
+            );
+        };
+
+        return $macro;
+    }
+
+    /**
+     * Create the withHead() macro for resource registrations, such as
+     * Route::resource('posts', PostController::class)->withHead(...).
+     */
+    protected function pendingResourceMacro(): Closure
+    {
+        /**
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        $macro = function (
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): PendingResourceRegistration {
+            $arguments = get_defined_vars();
+
+            $registration = HeadRouteMacros::bound($this, PendingResourceRegistration::class);
+
+            return $registration->metadata(
+                RouteAttributeParser::metadataFromArguments($arguments)
+            );
+        };
+
+        return $macro;
+    }
+
+    /**
+     * Create the withHead() macro for singleton resource registrations, such
+     * as Route::singleton('profile', ProfileController::class)->withHead(...).
+     */
+    protected function pendingSingletonMacro(): Closure
+    {
+        /**
+         * @param  array<mixed, mixed>|string|null  $title
+         * @param  array<mixed, mixed>|string|true|null  $canonical
+         * @param  array<int, string|RobotsRule>|string|RobotsRule|null  $robots
+         * @param  array<string, mixed>|null  $og
+         * @param  array<mixed, mixed>|string|null  $ogImage
+         * @param  array<mixed, mixed>|string|null  $ogVideo
+         * @param  array<mixed, mixed>|string|null  $ogAudio
+         * @param  array<string, mixed>|null  $twitter
+         * @param  array<mixed, mixed>|string|null  $twitterImage
+         * @param  array<mixed, mixed>|string|null  $preload
+         * @param  array<mixed, mixed>|string|null  $prefetch
+         * @param  array<mixed, mixed>|string|null  $preconnect
+         * @param  array<mixed, mixed>|string|null  $dnsPrefetch
+         * @param  array<string, string>|null  $alternates
+         * @param  array<mixed, mixed>|string|null  $feed
+         * @param  array<mixed, mixed>|string|null  $icon
+         * @param  array<mixed, mixed>|string|null  $favicon
+         * @param  array<mixed, mixed>|string|null  $appleTouchIcon
+         * @param  array<mixed, mixed>|string|null  $appleTouchStartupImage
+         * @param  array<mixed, mixed>|string|null  $maskIcon
+         * @param  array<mixed, mixed>|string|null  $manifest
+         * @param  array<mixed, mixed>|null  $schema
+         * @param  array<mixed, mixed>|null  $meta
+         * @param  array<mixed, mixed>|null  $link
+         * @param  array<string, mixed>  $extensions
+         */
+        $macro = function (
+            string|array|null $title = null,
+            ?string $description = null,
+            string|array|true|null $canonical = null,
+            string|RobotsRule|array|null $robots = null,
+            ?string $themeColor = null,
+            ?string $applicationName = null,
+            ?string $colorScheme = null,
+            ?string $referrer = null,
+            ?string $viewport = null,
+            ?string $appleWebAppTitle = null,
+            ?bool $webAppCapable = null,
+            ?string $appleWebAppStatusBarStyle = null,
+            ?array $og = null,
+            string|array|null $ogImage = null,
+            string|array|null $ogVideo = null,
+            string|array|null $ogAudio = null,
+            ?array $twitter = null,
+            string|array|null $twitterImage = null,
+            string|array|null $preload = null,
+            string|array|null $prefetch = null,
+            string|array|null $preconnect = null,
+            string|array|null $dnsPrefetch = null,
+            ?array $alternates = null,
+            string|array|null $feed = null,
+            string|array|null $icon = null,
+            string|array|null $favicon = null,
+            string|array|null $appleTouchIcon = null,
+            string|array|null $appleTouchStartupImage = null,
+            string|array|null $maskIcon = null,
+            string|array|null $manifest = null,
+            ?array $schema = null,
+            ?array $meta = null,
+            ?array $link = null,
+            array $extensions = [],
+        ): PendingSingletonResourceRegistration {
+            $arguments = get_defined_vars();
+
+            $registration = HeadRouteMacros::bound($this, PendingSingletonResourceRegistration::class);
+
+            return $registration->metadata(
+                RouteAttributeParser::metadataFromArguments($arguments)
+            );
+        };
+
+        return $macro;
+    }
+}

--- a/src/Routing/RouteAttributeParser.php
+++ b/src/Routing/RouteAttributeParser.php
@@ -53,6 +53,34 @@ class RouteAttributeParser
     }
 
     /**
+     * Wrap named head arguments in a cache-friendly route metadata layer,
+     * discarding arguments that were not provided.
+     *
+     * @param  array<mixed, mixed>  $arguments
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    public static function metadataFromArguments(array $arguments): array
+    {
+        $extensions = $arguments['extensions'] ?? [];
+
+        unset($arguments['extensions']);
+
+        if (is_array($extensions)) {
+            $arguments += $extensions;
+        }
+
+        $attributes = [];
+
+        foreach ($arguments as $key => $value) {
+            if (is_string($key) && ! is_null($value)) {
+                $attributes[$key] = $value;
+            }
+        }
+
+        return static::metadata($attributes);
+    }
+
+    /**
      * Get the head attribute layers stored in the route's metadata.
      *
      * @return array<int, array<mixed, mixed>>

--- a/tests/Feature/ErrorPagesTest.php
+++ b/tests/Feature/ErrorPagesTest.php
@@ -19,10 +19,10 @@ it('lets error head beat the resolved page head', function (): void {
         );
     });
 
-    Route::get('/missing', fn (): string => Head::toHtml(404))->metadata(Head::forMetadata(
+    Route::get('/missing', fn (): string => Head::toHtml(404))->withHead(
         title: 'Original Page',
         description: 'Original description.',
-    ));
+    );
 
     $this->get('/missing')
         ->assertOk()
@@ -42,9 +42,9 @@ it('accepts head builder callbacks for error metadata', function (): void {
             ->description('The page could not be found.'));
     });
 
-    Route::get('/missing', fn (): string => Head::toHtml(404))->metadata(Head::forMetadata(
+    Route::get('/missing', fn (): string => Head::toHtml(404))->withHead(
         title: 'Original Page',
-    ));
+    );
 
     $this->get('/missing')
         ->assertOk()

--- a/tests/Feature/HeadDataTest.php
+++ b/tests/Feature/HeadDataTest.php
@@ -35,7 +35,7 @@ it('resolves custom builder values from route attributes', function (): void {
     Head::extend(ReadingTime::class);
 
     Route::get('/article', fn (): string => Head::toHtml())
-        ->metadata(Head::forMetadata(extensions: ['readingTime' => 4]));
+        ->withHead(extensions: ['readingTime' => 4]);
 
     $this->get('/article')
         ->assertOk()

--- a/tests/Feature/InertiaCustomPropTest.php
+++ b/tests/Feature/InertiaCustomPropTest.php
@@ -23,7 +23,7 @@ class InertiaCustomPropTest extends TestCase
     {
         Route::get('/dashboard', fn () => Inertia::render('Dashboard', [
             'head' => 'An unrelated app prop',
-        ]))->metadata(Head::forMetadata(title: 'Dashboard'));
+        ]))->withHead(title: 'Dashboard');
 
         $this->get('/dashboard', [Header::INERTIA => 'true'])
             ->assertOk()

--- a/tests/Feature/InertiaTest.php
+++ b/tests/Feature/InertiaTest.php
@@ -14,10 +14,10 @@ it('shares rendered head elements with inertia page objects', function (): void 
 
     Route::get('/dashboard', fn () => Inertia::render('Dashboard', [
         'user' => 'Taylor',
-    ]))->metadata(Head::forMetadata(
+    ]))->withHead(
         title: 'Dashboard',
         description: 'Your application overview.',
-    ));
+    );
 
     $response = $this->get('/dashboard', [Header::INERTIA => 'true'])
         ->assertOk()
@@ -32,16 +32,16 @@ it('shares rendered head elements with inertia page objects', function (): void 
 });
 
 it('shares stable semantic inertia keys for each head element', function (): void {
-    Route::get('/lean', fn () => Inertia::render('Page'))->metadata(Head::forMetadata(
+    Route::get('/lean', fn () => Inertia::render('Page'))->withHead(
         description: 'Lean page.',
-    ));
+    );
 
-    Route::get('/rich', fn () => Inertia::render('Page'))->metadata(Head::forMetadata(
+    Route::get('/rich', fn () => Inertia::render('Page'))->withHead(
         title: 'Rich page',
         description: 'Rich page.',
         preload: [['href' => '/fonts/inter.woff2', 'as' => 'font']],
         ogImage: 'https://example.com/rich.jpg',
-    ));
+    );
 
     $lean = $this->get('/lean', [Header::INERTIA => 'true'])->json('props.'.HeadManager::INERTIA_PROP);
     $rich = $this->get('/rich', [Header::INERTIA => 'true'])->json('props.'.HeadManager::INERTIA_PROP);
@@ -59,7 +59,7 @@ it('shares stable semantic inertia keys for each head element', function (): voi
 it('keeps head elements off the wire during inertia partial reloads', function (): void {
     Route::get('/dashboard', fn () => Inertia::render('Dashboard', [
         'user' => 'Taylor',
-    ]))->metadata(Head::forMetadata(title: 'Dashboard'));
+    ]))->withHead(title: 'Dashboard');
 
     $this->get('/dashboard', [
         Header::INERTIA => 'true',
@@ -76,10 +76,10 @@ it('keeps inertia globals out of inertia page objects', function (): void {
         ->viewport('width=device-width, initial-scale=1')
         ->icon('/favicon.svg', type: 'image/svg+xml'));
 
-    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->metadata(Head::forMetadata(
+    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->withHead(
         title: 'Dashboard',
         description: 'Dashboard overview.',
-    ));
+    );
 
     $elements = $this->get('/dashboard', [Header::INERTIA => 'true'])
         ->assertOk()
@@ -99,10 +99,10 @@ it('renders inertia globals as static tags and page tags as inertia-managed tags
         ->viewport('width=device-width, initial-scale=1')
         ->icon('/favicon.svg', type: 'image/svg+xml'));
 
-    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->metadata(Head::forMetadata(
+    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->withHead(
         title: 'Dashboard',
         description: 'Dashboard overview.',
-    ));
+    );
 
     $this->get('/dashboard')
         ->assertOk()

--- a/tests/Feature/LivewireTest.php
+++ b/tests/Feature/LivewireTest.php
@@ -3,18 +3,17 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
-use Laravel\Head\Facades\Head;
 
 it('renders fresh route head data in livewire navigate documents', function (): void {
-    Route::get('/first', fn () => view('livewire-layout', ['href' => '/second']))->metadata(Head::forMetadata(
+    Route::get('/first', fn () => view('livewire-layout', ['href' => '/second']))->withHead(
         title: 'First Page',
         description: 'The first page.',
-    ));
+    );
 
-    Route::get('/second', fn () => view('livewire-layout', ['href' => '/first']))->metadata(Head::forMetadata(
+    Route::get('/second', fn () => view('livewire-layout', ['href' => '/first']))->withHead(
         title: 'Second Page',
         description: 'The second page.',
-    ));
+    );
 
     $this->get('/first')
         ->assertOk()

--- a/tests/Feature/Routing/RouteHeadTest.php
+++ b/tests/Feature/Routing/RouteHeadTest.php
@@ -17,14 +17,14 @@ it('cascades defaults route groups routes and controller mutations', function ()
             ->description('Default description.');
     });
 
-    Route::metadata(Head::forMetadata(description: 'Admin description.', robots: 'noindex, nofollow'))
+    Route::withHead(description: 'Admin description.', robots: 'noindex, nofollow')
         ->prefix('admin')
         ->group(function (): void {
             Route::get('/dashboard', function (): string {
                 Head::title('Runtime dashboard');
 
                 return Head::toHtml();
-            })->metadata(Head::forMetadata(title: 'Dashboard'));
+            })->withHead(title: 'Dashboard');
         });
 
     $this->get('/admin/dashboard')
@@ -35,14 +35,14 @@ it('cascades defaults route groups routes and controller mutations', function ()
 });
 
 it('keeps route group head metadata as a separate cascade layer', function (): void {
-    Route::metadata(Head::forMetadata(
+    Route::withHead(
         description: 'Admin reports',
         og: ['siteName' => 'Acme'],
-    ))
+    )
         ->prefix('admin')
         ->group(function (): void {
             Route::get('/dashboard', fn (): string => Head::toHtml())
-                ->metadata(Head::forMetadata(title: 'Dashboard', og: ['title' => 'Dashboard']));
+                ->withHead(title: 'Dashboard', og: ['title' => 'Dashboard']);
         });
 
     $this->get('/admin/dashboard')
@@ -54,14 +54,14 @@ it('keeps route group head metadata as a separate cascade layer', function (): v
 });
 
 it('stores cache friendly head metadata on view and controller routes', function (): void {
-    $view = Route::view('/contact', 'contact')->metadata(Head::forMetadata(
+    $view = Route::view('/contact', 'contact')->withHead(
         title: 'Contact',
         description: 'Get in touch.',
-    ));
+    );
 
-    $controller = Route::get('/about', fn (): string => 'About')->metadata(Head::forMetadata(
+    $controller = Route::get('/about', fn (): string => 'About')->withHead(
         title: 'About',
-    ));
+    );
 
     expect(array_values($view->getMetadata(RouteAttributeParser::HEAD)))->toBe([[
         'title' => 'Contact',
@@ -71,21 +71,14 @@ it('stores cache friendly head metadata on view and controller routes', function
     ]]);
 });
 
-it('rejects unknown named route metadata arguments', function (): void {
-    $arguments = ['heading' => 'Dashboard'];
-
-    expect(fn (): array => Head::forMetadata(...$arguments))
-        ->toThrow(Error::class, 'Unknown named parameter $heading');
-});
-
 it('stores head metadata on resource and singleton routes', function (): void {
-    Route::resource('posts', 'PostController')->metadata(Head::forMetadata(
+    Route::resource('posts', 'PostController')->withHead(
         robots: 'index, follow',
-    ));
+    );
 
-    Route::singleton('profile', 'ProfileController')->metadata(Head::forMetadata(
+    Route::singleton('profile', 'ProfileController')->withHead(
         title: 'Your Profile',
-    ));
+    );
 
     $posts = Route::getRoutes()->getByName('posts.index');
     $profile = Route::getRoutes()->getByName('profile.show');
@@ -98,7 +91,7 @@ it('stores head metadata on resource and singleton routes', function (): void {
 });
 
 it('parses route head data using the fluent field shapes', function (): void {
-    Route::get('/product', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/product', fn (): string => Head::toHtml())->withHead(
         title: ['value' => 'Product', 'suffix' => ' - Store'],
         canonical: ['auto' => true, 'forceHttps' => false],
         og: ['type' => OgType::Website, 'image' => 'https://example.com/og.jpg'],
@@ -111,7 +104,7 @@ it('parses route head data using the fluent field shapes', function (): void {
         link: [
             ['rel' => 'manifest', 'href' => '/manifest.json'],
         ],
-    ));
+    );
 
     $this->get('/product')
         ->assertOk()
@@ -129,13 +122,13 @@ it('parses route head data using the fluent field shapes', function (): void {
 });
 
 it('does not accept snake case route head data aliases', function (): void {
-    Route::get('/legacy-inputs', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/legacy-inputs', fn (): string => Head::toHtml())->withHead(
         canonical: ['auto' => true, 'force_https' => false],
         og: ['title' => 'Legacy', 'site_name' => 'Legacy'],
         ogImage: [
             ['url' => 'https://example.com/image.jpg', 'secure_url' => 'https://secure.example.com/image.jpg'],
         ],
-    ));
+    );
 
     $this->get('/legacy-inputs')
         ->assertOk()
@@ -146,13 +139,13 @@ it('does not accept snake case route head data aliases', function (): void {
 });
 
 it('parses single repeatable route head data values', function (): void {
-    Route::get('/assets', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/assets', fn (): string => Head::toHtml())->withHead(
         preload: ['href' => '/fonts/inter.woff2', 'as' => 'font', 'crossorigin' => true],
         prefetch: '/images/next.webp',
         preconnect: ['href' => 'https://fonts.example.com', 'crossorigin' => true],
         dnsPrefetch: 'https://analytics.example.com',
         feed: ['href' => '/feed.atom', 'title' => 'Acme Atom', 'type' => 'atom'],
-    ));
+    );
 
     $this->get('/assets')
         ->assertOk()
@@ -174,9 +167,9 @@ it('throws for unknown route head data keys', function (): void {
 })->throws(InvalidArgumentException::class, 'Unknown route head attribute [heading].');
 
 it('throws for invalid values on known route head data keys', function (): void {
-    Route::get('/invalid-head-value', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/invalid-head-value', fn (): string => Head::toHtml())->withHead(
         ogImage: ['alt' => 'Missing URL'],
-    ));
+    );
 
     $this->withoutExceptionHandling()->get('/invalid-head-value');
 })->throws(InvalidArgumentException::class, 'Invalid value for route head attribute [ogImage].');
@@ -192,9 +185,9 @@ it('throws when route head data tries to suppress canonical URLs', function (): 
 })->throws(InvalidArgumentException::class, 'Invalid value for route head attribute [canonical].');
 
 it('throws when route canonical data uses the removed none option', function (): void {
-    Route::get('/invalid-canonical-none', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/invalid-canonical-none', fn (): string => Head::toHtml())->withHead(
         canonical: ['none' => true],
-    ));
+    );
 
     $this->withoutExceptionHandling()->get('/invalid-canonical-none');
 })->throws(InvalidArgumentException::class, 'Invalid value for route head attribute [canonical].');

--- a/tests/Feature/Routing/WithHeadTest.php
+++ b/tests/Feature/Routing/WithHeadTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Laravel\Head\Facades\Head;
+use Laravel\Head\Routing\RouteAttributeParser;
+
+it('defines head metadata fluently on routes', function (): void {
+    $route = Route::view('/contact', 'contact')
+        ->name('contact')
+        ->withHead(
+            title: 'Contact Us',
+            description: 'Get in touch.',
+        );
+
+    expect($route)->toBeInstanceOf(Illuminate\Routing\Route::class)
+        ->and($route->getName())->toBe('contact')
+        ->and(array_values($route->getMetadata(RouteAttributeParser::HEAD)))->toBe([[
+            'title' => 'Contact Us',
+            'description' => 'Get in touch.',
+        ]]);
+});
+
+it('defines head metadata at the leading group position', function (): void {
+    Route::withHead(description: 'Admin description.', robots: 'noindex, nofollow')
+        ->prefix('admin')
+        ->group(function (): void {
+            Route::get('/dashboard', fn (): string => Head::toHtml())
+                ->withHead(title: 'Dashboard');
+        });
+
+    $this->get('/admin/dashboard')
+        ->assertOk()
+        ->assertSee('<title>Dashboard</title>', false)
+        ->assertSee('<meta name="description" content="Admin description.">', false)
+        ->assertSee('<meta name="robots" content="noindex, nofollow">', false);
+});
+
+it('defines head metadata after other group attributes', function (): void {
+    Route::prefix('admin')
+        ->withHead(og: ['siteName' => 'Acme'])
+        ->name('admin.')
+        ->group(function (): void {
+            Route::get('/reports', fn (): string => Head::toHtml())
+                ->name('reports')
+                ->withHead(title: 'Reports', og: ['title' => 'Reports']);
+        });
+
+    $this->get('/admin/reports')
+        ->assertOk()
+        ->assertSee('<title>Reports</title>', false)
+        ->assertSee('<meta property="og:site_name" content="Acme">', false)
+        ->assertSee('<meta property="og:title" content="Reports">', false);
+});
+
+it('defines head metadata on resource and singleton routes', function (): void {
+    Route::resource('posts', 'PostController')->withHead(
+        robots: 'index, follow',
+    );
+
+    Route::singleton('profile', 'ProfileController')->withHead(
+        title: 'Your Profile',
+    );
+
+    $posts = Route::getRoutes()->getByName('posts.index');
+    $profile = Route::getRoutes()->getByName('profile.show');
+
+    expect(array_values($posts?->getMetadata(RouteAttributeParser::HEAD)))->toBe([[
+        'robots' => 'index, follow',
+    ]])->and(array_values($profile?->getMetadata(RouteAttributeParser::HEAD)))->toBe([[
+        'title' => 'Your Profile',
+    ]]);
+});
+
+it('stores cache friendly metadata including extension attributes', function (): void {
+    $route = Route::get('/article', fn (): string => 'Article')->withHead(
+        title: 'Article',
+        extensions: ['readingTime' => 4],
+    );
+
+    expect(array_values($route->getMetadata(RouteAttributeParser::HEAD)))->toBe([[
+        'title' => 'Article',
+        'readingTime' => 4,
+    ]]);
+});
+
+it('rejects unknown named withHead arguments', function (): void {
+    $arguments = ['heading' => 'Dashboard'];
+
+    expect(fn () => Route::get('/unknown', fn (): string => 'Unknown')->withHead(...$arguments))
+        ->toThrow(Error::class, 'Unknown named parameter $heading');
+});

--- a/tests/Feature/Tags/CanonicalTest.php
+++ b/tests/Feature/Tags/CanonicalTest.php
@@ -14,7 +14,7 @@ it('carries inherited canonical options into later canonical URLs', function ():
     Head::defaults(fn (HeadBuilder $head): HeadBuilder => $head->canonical(forceHttps: false, trailingSlash: true));
 
     Route::get('/about', fn (): string => Head::toHtml())
-        ->metadata(Head::forMetadata(canonical: '/about'));
+        ->withHead(canonical: '/about');
 
     $this->get('/about')
         ->assertOk()

--- a/tests/Feature/Tags/GenericLinksTest.php
+++ b/tests/Feature/Tags/GenericLinksTest.php
@@ -36,7 +36,7 @@ it('renders link aliases', function (): void {
 });
 
 it('resolves link aliases from route attributes', function (): void {
-    Route::get('/app', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/app', fn (): string => Head::toHtml())->withHead(
         icon: [
             ['href' => '/favicon.svg', 'type' => ImageType::Svg],
             ['href' => '/favicon-32x32.png', 'type' => ImageType::Png, 'sizes' => '32x32'],
@@ -46,7 +46,7 @@ it('resolves link aliases from route attributes', function (): void {
         maskIcon: ['href' => '/safari-pinned-tab.svg', 'color' => '#111827'],
         manifest: '/site.webmanifest',
         appleTouchStartupImage: ['href' => '/launch.png', 'media' => Media::Portrait],
-    ));
+    );
 
     $this->get('/app')
         ->assertOk()

--- a/tests/Feature/Tags/MetaTagsTest.php
+++ b/tests/Feature/Tags/MetaTagsTest.php
@@ -67,12 +67,12 @@ it('serializes media-specific meta tags to the head array', function (): void {
 });
 
 it('resolves media-specific meta tags from route attributes', function (): void {
-    Route::get('/dashboard', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/dashboard', fn (): string => Head::toHtml())->withHead(
         meta: [
             ['key' => 'theme-color', 'content' => '#ffffff', 'media' => '(prefers-color-scheme: light)'],
             ['key' => 'theme-color', 'content' => '#111827', 'media' => '(prefers-color-scheme: dark)'],
         ],
-    ));
+    );
 
     $this->get('/dashboard')
         ->assertOk()
@@ -81,12 +81,12 @@ it('resolves media-specific meta tags from route attributes', function (): void 
 });
 
 it('resolves media enum values from route attributes', function (): void {
-    Route::get('/dashboard', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/dashboard', fn (): string => Head::toHtml())->withHead(
         meta: [
             ['key' => 'theme-color', 'content' => '#ffffff', 'media' => Media::Light],
             ['key' => 'theme-color', 'content' => '#111827', 'media' => Media::Dark],
         ],
-    ));
+    );
 
     $this->get('/dashboard')
         ->assertOk()
@@ -95,7 +95,7 @@ it('resolves media enum values from route attributes', function (): void {
 });
 
 it('resolves meta aliases from route attributes', function (): void {
-    Route::get('/settings', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/settings', fn (): string => Head::toHtml())->withHead(
         applicationName: 'Acme',
         colorScheme: 'light dark',
         referrer: 'strict-origin',
@@ -103,7 +103,7 @@ it('resolves meta aliases from route attributes', function (): void {
         appleWebAppTitle: 'Acme',
         webAppCapable: true,
         appleWebAppStatusBarStyle: 'black-translucent',
-    ));
+    );
 
     $this->get('/settings')
         ->assertOk()

--- a/tests/Feature/Tags/RobotsTest.php
+++ b/tests/Feature/Tags/RobotsTest.php
@@ -48,7 +48,7 @@ it('renders robots tags from mixed string and enum rules', function (): void {
 
 it('resolves robots rules from route attributes', function (): void {
     Route::get('/private', fn (): string => Head::toHtml())
-        ->metadata(Head::forMetadata(robots: [RobotsRule::NoIndex, RobotsRule::NoFollow]));
+        ->withHead(robots: [RobotsRule::NoIndex, RobotsRule::NoFollow]);
 
     $this->get('/private')
         ->assertOk()

--- a/tests/Feature/Tags/ThemeColorTest.php
+++ b/tests/Feature/Tags/ThemeColorTest.php
@@ -32,9 +32,9 @@ it('provides common media query values', function (): void {
 });
 
 it('resolves theme colors from route attributes', function (): void {
-    Route::get('/product', fn (): string => Head::toHtml())->metadata(Head::forMetadata(
+    Route::get('/product', fn (): string => Head::toHtml())->withHead(
         themeColor: '#0f172a',
-    ));
+    );
 
     $this->get('/product')
         ->assertOk()
@@ -42,9 +42,9 @@ it('resolves theme colors from route attributes', function (): void {
 });
 
 it('shares stable inertia keys for theme colors', function (): void {
-    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->metadata(Head::forMetadata(
+    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))->withHead(
         themeColor: '#0f172a',
-    ));
+    );
 
     $this->get('/dashboard', [Header::INERTIA => 'true'])
         ->assertOk()


### PR DESCRIPTION
This PR replaces `->metadata(Head::forMetadata(...))` with a `withHead()` macro. The macro includes a full named-parameter signature providing support for static analysis. The PR also bundles an `_ide_helper.php` stub for autocompletion support. The macro delegates directly to Laravel's native route metadata API, so routes store a cache-friendly array.

```php
// Before
Route::view('/dashboard', 'dashboard')->metadata(Head::forMetadata(
    themeColor: '#0f172a',
));

// After
Route::view('/dashboard', 'dashboard')->withHead(themeColor: '#0f172a');
```
