### PR TITLE
Fix octane with inertia

### DIFF
--- a/src/Inertia/Integration.php
+++ b/src/Inertia/Integration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Head\Inertia;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Http\Kernel;
 use Inertia\Inertia;
 use Inertia\Ssr\Gateway;
 use Laravel\Head\HeadManager;
@@ -24,14 +25,19 @@ class Integration
         }
 
         $this->decorateSsrGateway();
+        $this->registerMiddleware();
+    }
 
-        $this->app->booted(function (): void {
-            $head = $this->app->make(HeadManager::class);
-
-            // A plain callable (rather than Inertia::always) keeps the elements
-            // off the wire during partial reloads; the client retains the head
-            // from the last full visit.
-            Inertia::share($head->inertiaProp(), fn (): array => $head->toInertiaElements());
+    /**
+     * Share head elements during every request so integrations such as Octane
+     * can safely flush Inertia's shared props between operations.
+     */
+    protected function registerMiddleware(): void
+    {
+        $this->app->afterResolving(Kernel::class, function (object $kernel): void {
+            if (method_exists($kernel, 'pushMiddleware')) {
+                $kernel->pushMiddleware(ShareHead::class);
+            }
         });
     }
 

--- a/src/Inertia/ShareHead.php
+++ b/src/Inertia/ShareHead.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Inertia;
+
+use Closure;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Laravel\Head\HeadManager;
+use Symfony\Component\HttpFoundation\Response;
+
+class ShareHead
+{
+    public function __construct(protected HeadManager $head) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): Response  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // A plain callable (rather than Inertia::always) keeps the elements
+        // off the wire during partial reloads; the client retains the head
+        // from the last full visit.
+        Inertia::share(
+            $this->head->inertiaProp(),
+            fn (): array => $this->head->toInertiaElements(),
+        );
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/InertiaTest.php
+++ b/tests/Feature/InertiaTest.php
@@ -33,6 +33,29 @@ it('shares rendered head elements with inertia page objects', function (): void 
         ->toContain('<meta data-inertia="description" name="description" content="Your application overview.">');
 });
 
+it('restores shared head elements after inertia flushes its shared props', function (): void {
+    Route::get('/dashboard', fn () => Inertia::render('Dashboard'))
+        ->withHead(title: 'Dashboard');
+
+    $headers = [Header::INERTIA => 'true'];
+
+    $this->get('/dashboard', $headers)
+        ->assertOk()
+        ->assertJsonPath(
+            'props.'.HeadManager::INERTIA_PROP.'.0',
+            '<title data-inertia="title">Dashboard</title>',
+        );
+
+    Inertia::flushShared();
+
+    $this->get('/dashboard', $headers)
+        ->assertOk()
+        ->assertJsonPath(
+            'props.'.HeadManager::INERTIA_PROP.'.0',
+            '<title data-inertia="title">Dashboard</title>',
+        );
+});
+
 it('shares stable semantic inertia keys for each head element', function (): void {
     Route::get('/lean', fn () => Inertia::render('Page'))->withHead(
         description: 'Lean page.',


### PR DESCRIPTION
Fixes #7.  `Inertia::share()` was registered once in `booted()`, so under Octane the head prop was wiped by `Inertia::flushShared()` after the first request and never re-shared.

This PR moves the share into a new `ShareHead` global middleware, registered via `afterResolving(Kernel::class)` so it re-runs on every request.
