### PR TITLE
Fix link attribute injection

### DIFF
--- a/src/Rendering/TagRenderer.php
+++ b/src/Rendering/TagRenderer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Head\Rendering;
 
+use InvalidArgumentException;
+
 class TagRenderer
 {
     public function __construct(protected bool $withInertiaAttributes = false)
@@ -23,7 +25,7 @@ class TagRenderer
     {
         $inertiaKey ??= 'title';
 
-        return '<title'.$this->inertiaAttribute($inertiaKey).'>'.e($title).'</title>';
+        return $this->element('title', e($title), $this->inertiaAttributes($inertiaKey));
     }
 
     /**
@@ -45,14 +47,23 @@ class TagRenderer
     {
         $inertiaKey ??= $key;
 
-        return '<meta'.$this->inertiaAttribute($inertiaKey).' '.$attribute.'="'.e($key).'" '.$this->attributes($attributes).'>';
+        return $this->voidElement(
+            'meta',
+            $this->inertiaAttributes($inertiaKey),
+            [$attribute => $key],
+            $attributes,
+        );
     }
 
     public function link(string $rel, string $href, ?string $inertiaKey = null): string
     {
         $inertiaKey ??= $this->stableKey($rel, $href);
 
-        return '<link'.$this->inertiaAttribute($inertiaKey).' rel="'.e($rel).'" href="'.e($href).'">';
+        return $this->voidElement(
+            'link',
+            $this->inertiaAttributes($inertiaKey),
+            ['rel' => $rel, 'href' => $href],
+        );
     }
 
     /**
@@ -62,7 +73,12 @@ class TagRenderer
     {
         $inertiaKey ??= $this->stableKey($rel, (string) ($attributes['href'] ?? serialize($attributes)));
 
-        return '<link'.$this->inertiaAttribute($inertiaKey).' rel="'.e($rel).'" '.$this->attributes($attributes).'>';
+        return $this->voidElement(
+            'link',
+            $this->inertiaAttributes($inertiaKey),
+            ['rel' => $rel],
+            $attributes,
+        );
     }
 
     /**
@@ -72,7 +88,12 @@ class TagRenderer
     {
         $inertiaKey ??= $this->stableKey('schema', json_encode($schema, JSON_THROW_ON_ERROR));
 
-        return '<script'.$this->inertiaAttribute($inertiaKey).' type="application/ld+json">'.json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR).'</script>';
+        return $this->element(
+            'script',
+            json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR),
+            $this->inertiaAttributes($inertiaKey),
+            ['type' => 'application/ld+json'],
+        );
     }
 
     /**
@@ -80,29 +101,17 @@ class TagRenderer
      */
     public function attributes(array $attributes): string
     {
-        return collect($attributes)
-            ->map(function (mixed $value, string $name): string {
-                if (is_null($value) || $value === false || ! $this->isValidAttributeName($name)) {
-                    return '';
-                }
-
-                if ($value === true) {
-                    return e($name);
-                }
-
-                return e($name).'="'.e((string) $value).'"';
-            })
-            ->filter()
-            ->implode(' ');
+        return $this->renderAttributes($attributes);
     }
 
     /**
-     * Names aren't HTML-escaped, so reject anything that could break out
-     * and inject another attribute (e.g. a space or "=").
+     * Attribute names aren't HTML-escaped, so reject anything that could
+     * break out of the attribute position. The "u" modifier also makes
+     * invalid UTF-8 fail the match.
      */
     protected function isValidAttributeName(string $name): bool
     {
-        return preg_match('/^[a-z_:][-\w:.]*$/i', $name) === 1;
+        return preg_match('/^[^\x00-\x20\x7F-\x9F"\'\/=>]+$/u', $name) === 1;
     }
 
     /**
@@ -113,8 +122,75 @@ class TagRenderer
         return $prefix.':'.substr(md5($value), 0, 16);
     }
 
-    protected function inertiaAttribute(?string $key): string
+    /**
+     * @param  array<int|string, bool|float|int|string|null>  ...$attributeSets
+     */
+    protected function renderAttributes(array ...$attributeSets): string
     {
-        return $this->withInertiaAttributes && ! is_null($key) ? ' data-inertia="'.e($key).'"' : '';
+        $rendered = [];
+        $seen = [];
+
+        foreach ($attributeSets as $attributes) {
+            foreach ($attributes as $name => $value) {
+                if ($value === false || is_null($value)) {
+                    continue;
+                }
+
+                $name = (string) $name;
+
+                if (! $this->isValidAttributeName($name)) {
+                    throw new InvalidArgumentException('Invalid HTML attribute name.');
+                }
+
+                $normalizedName = strtolower($name);
+
+                if (isset($seen[$normalizedName])) {
+                    throw new InvalidArgumentException("Duplicate HTML attribute name [{$name}].");
+                }
+
+                $seen[$normalizedName] = true;
+                $rendered[] = $value === true
+                    ? $name
+                    : $name.'="'.e((string) $value).'"';
+            }
+        }
+
+        return implode(' ', $rendered);
+    }
+
+    /**
+     * @param  array<int|string, bool|float|int|string|null>  ...$attributeSets
+     */
+    protected function voidElement(string $name, array ...$attributeSets): string
+    {
+        return '<'.$name.$this->renderedAttributes(...$attributeSets).'>';
+    }
+
+    /**
+     * @param  array<int|string, bool|float|int|string|null>  ...$attributeSets
+     */
+    protected function element(string $name, string $content, array ...$attributeSets): string
+    {
+        return '<'.$name.$this->renderedAttributes(...$attributeSets).'>'.$content.'</'.$name.'>';
+    }
+
+    /**
+     * @param  array<int|string, bool|float|int|string|null>  ...$attributeSets
+     */
+    protected function renderedAttributes(array ...$attributeSets): string
+    {
+        $attributes = $this->renderAttributes(...$attributeSets);
+
+        return $attributes === '' ? '' : ' '.$attributes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function inertiaAttributes(?string $key): array
+    {
+        return $this->withInertiaAttributes && ! is_null($key)
+            ? ['data-inertia' => $key]
+            : [];
     }
 }

--- a/src/Rendering/TagRenderer.php
+++ b/src/Rendering/TagRenderer.php
@@ -82,16 +82,12 @@ class TagRenderer
     {
         return collect($attributes)
             ->map(function (mixed $value, string $name): string {
-                if (! $this->isValidAttributeName($name)) {
+                if (is_null($value) || $value === false || ! $this->isValidAttributeName($name)) {
                     return '';
                 }
 
                 if ($value === true) {
                     return e($name);
-                }
-
-                if ($value === false || is_null($value)) {
-                    return '';
                 }
 
                 return e($name).'="'.e((string) $value).'"';

--- a/src/Rendering/TagRenderer.php
+++ b/src/Rendering/TagRenderer.php
@@ -82,6 +82,10 @@ class TagRenderer
     {
         return collect($attributes)
             ->map(function (mixed $value, string $name): string {
+                if (! $this->isValidAttributeName($name)) {
+                    return '';
+                }
+
                 if ($value === true) {
                     return e($name);
                 }
@@ -94,6 +98,15 @@ class TagRenderer
             })
             ->filter()
             ->implode(' ');
+    }
+
+    /**
+     * Names aren't HTML-escaped, so reject anything that could break out
+     * and inject another attribute (e.g. a space or "=").
+     */
+    protected function isValidAttributeName(string $name): bool
+    {
+        return preg_match('/^[a-z_:][-\w:.]*$/i', $name) === 1;
     }
 
     /**

--- a/tests/Feature/Rendering/TagRendererTest.php
+++ b/tests/Feature/Rendering/TagRendererTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Head\Rendering\TagRenderer;
+
+it('drops attributes whose name contains whitespace or an equals sign', function (): void {
+    $tags = new TagRenderer;
+
+    expect($tags->attributes(['onerror x' => '1']))->toBe('')
+        ->and($tags->attributes(['foo=bar' => '1']))->toBe('')
+        ->and($tags->attributes(['foo"bar' => '1']))->toBe('')
+        ->and($tags->attributes(["foo\nbar" => '1']))->toBe('')
+        ->and($tags->attributes(['onerror x' => true]))->toBe('');
+});
+
+it('keeps well-formed attribute names', function (): void {
+    $tags = new TagRenderer;
+
+    expect($tags->attributes(['data-inertia' => 'title']))->toBe('data-inertia="title"')
+        ->and($tags->attributes(['crossorigin' => true]))->toBe('crossorigin')
+        ->and($tags->attributes(['aria-label' => 'Close', 'tabindex' => '0']))->toBe('aria-label="Close" tabindex="0"');
+});
+
+it('does not let a malicious attribute name break out of a link tag', function (): void {
+    $tags = new TagRenderer;
+
+    $html = $tags->linkWithAttributes('stylesheet', [
+        'href' => '/theme.css',
+        'onerror x' => '1',
+    ]);
+
+    expect($html)
+        ->toBe('<link rel="stylesheet" href="/theme.css">')
+        ->not->toContain('onerror');
+});

--- a/tests/Feature/Rendering/TagRendererTest.php
+++ b/tests/Feature/Rendering/TagRendererTest.php
@@ -4,33 +4,47 @@ declare(strict_types=1);
 
 use Laravel\Head\Rendering\TagRenderer;
 
-it('drops attributes whose name contains whitespace or an equals sign', function (): void {
-    $tags = new TagRenderer;
-
-    expect($tags->attributes(['onerror x' => '1']))->toBe('')
-        ->and($tags->attributes(['foo=bar' => '1']))->toBe('')
-        ->and($tags->attributes(['foo"bar' => '1']))->toBe('')
-        ->and($tags->attributes(["foo\nbar" => '1']))->toBe('')
-        ->and($tags->attributes(['onerror x' => true]))->toBe('');
-});
-
-it('keeps well-formed attribute names', function (): void {
+it('renders valid HTML attribute names without changing them', function (): void {
     $tags = new TagRenderer;
 
     expect($tags->attributes(['data-inertia' => 'title']))->toBe('data-inertia="title"')
         ->and($tags->attributes(['crossorigin' => true]))->toBe('crossorigin')
-        ->and($tags->attributes(['aria-label' => 'Close', 'tabindex' => '0']))->toBe('aria-label="Close" tabindex="0"');
+        ->and($tags->attributes(['aria-label' => 'Close', 'tabindex' => '0']))->toBe('aria-label="Close" tabindex="0"')
+        ->and($tags->attributes(['@click' => 'close', '-custom' => 'value']))->toBe('@click="close" -custom="value"')
+        ->and($tags->attributes(['1custom' => 'value', 'café' => 'yes']))->toBe('1custom="value" café="yes"')
+        ->and($tags->attributes(['foo&bar' => 'value']))->toBe('foo&bar="value"')
+        ->and($tags->attributes(['123' => 'value']))->toBe('123="value"');
 });
 
-it('does not let a malicious attribute name break out of a link tag', function (): void {
+it('rejects invalid HTML attribute names', function (string $name): void {
     $tags = new TagRenderer;
 
-    $html = $tags->linkWithAttributes('stylesheet', [
-        'href' => '/theme.css',
-        'onerror x' => '1',
-    ]);
+    expect(fn (): string => $tags->attributes([$name => 'value']))
+        ->toThrow(InvalidArgumentException::class, 'Invalid HTML attribute name.');
+})->with([
+    'empty' => '',
+    'space' => 'onerror x',
+    'equals' => 'foo=bar',
+    'double quote' => 'foo"bar',
+    'single quote' => "foo'bar",
+    'slash' => 'foo/bar',
+    'greater than' => 'foo>bar',
+    'control' => "foo\nbar",
+    'invalid utf-8' => "foo\xC3\x28bar",
+]);
 
-    expect($html)
-        ->toBe('<link rel="stylesheet" href="/theme.css">')
-        ->not->toContain('onerror');
+it('validates attribute names supplied directly to tag methods', function (): void {
+    $tags = new TagRenderer;
+
+    expect(fn (): string => $tags->metaWithAttributes('name onerror', 'description', ['content' => 'Value']))
+        ->toThrow(InvalidArgumentException::class, 'Invalid HTML attribute name.');
+});
+
+it('rejects case-insensitive duplicate attributes', function (): void {
+    $tags = new TagRenderer;
+
+    expect(fn (): string => $tags->linkWithAttributes('stylesheet', [
+        'REL' => 'alternate',
+        'href' => '/theme.css',
+    ]))->toThrow(InvalidArgumentException::class, 'Duplicate HTML attribute name [REL].');
 });

--- a/tests/Feature/Tags/GenericLinksTest.php
+++ b/tests/Feature/Tags/GenericLinksTest.php
@@ -35,12 +35,11 @@ it('renders link aliases', function (): void {
         ->toContain('rel="apple-touch-startup-image" href="/launch.png" media="(orientation: portrait)">');
 });
 
-it('drops link attributes with unsafe names instead of injecting them', function (): void {
+it('rejects link attributes with unsafe names', function (): void {
     Head::link('stylesheet', '/theme.css', ['onerror x' => 'alert(1)']);
 
-    expect(Head::toHtml())
-        ->toContain('rel="stylesheet" href="/theme.css">')
-        ->not->toContain('onerror');
+    expect(fn (): string => Head::toHtml())
+        ->toThrow(InvalidArgumentException::class, 'Invalid HTML attribute name.');
 });
 
 it('resolves link aliases from route attributes', function (): void {

--- a/tests/Feature/Tags/GenericLinksTest.php
+++ b/tests/Feature/Tags/GenericLinksTest.php
@@ -35,6 +35,14 @@ it('renders link aliases', function (): void {
         ->toContain('rel="apple-touch-startup-image" href="/launch.png" media="(orientation: portrait)">');
 });
 
+it('drops link attributes with unsafe names instead of injecting them', function (): void {
+    Head::link('stylesheet', '/theme.css', ['onerror x' => 'alert(1)']);
+
+    expect(Head::toHtml())
+        ->toContain('rel="stylesheet" href="/theme.css">')
+        ->not->toContain('onerror');
+});
+
 it('resolves link aliases from route attributes', function (): void {
     Route::get('/app', fn (): string => Head::toHtml())->withHead(
         icon: [


### PR DESCRIPTION
Head::link() (and the withHead() route macro) let you pass arbitrary HTML attribute names. The values were HTML-escaped, but the names weren't, so an attribute name containing a space could inject an extra attribute into the rendered tag, e.g.:

```php
Head::link('stylesheet', '/theme.css', ['onerror x' => '1']);
// <link rel="stylesheet" href="/theme.css" onerror x="1">
```

This adds a basic well-formedness check on attribute names in TagRenderer and drops anything that doesn't look like a real HTML attribute name. Added tests covering both the low-level renderer and the public Head::link() API.