### PR TITLE
Remove dead use statements in InertiaTest

### DIFF
--- a/tests/Feature/InertiaTest.php
+++ b/tests/Feature/InertiaTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Closure;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Inertia\Ssr\DisablesSsr;
@@ -14,7 +13,6 @@ use Inertia\Support\Header;
 use Laravel\Head\Facades\Head;
 use Laravel\Head\HeadBuilder;
 use Laravel\Head\HeadManager;
-use LogicException;
 
 it('shares rendered head elements with inertia page objects', function (): void {
     Head::defaults(fn (HeadBuilder $head) => $head->title('Acme', suffix: ' - Acme'));


### PR DESCRIPTION
Pest flagged two unused-effect `use` statements (`Closure`, `LogicException`) in `tests/Feature/InertiaTest.php` — both are global-namespace classes, so the imports did nothing. Removed them.