### PR TITLE
Fix Inertia middleware registration for resolved kernels

### DIFF
--- a/src/Inertia/Integration.php
+++ b/src/Inertia/Integration.php
@@ -34,11 +34,17 @@ class Integration
      */
     protected function registerMiddleware(): void
     {
-        $this->app->afterResolving(Kernel::class, function (object $kernel): void {
+        $push = static function (object $kernel): void {
             if (method_exists($kernel, 'pushMiddleware')) {
                 $kernel->pushMiddleware(ShareHead::class);
             }
-        });
+        };
+
+        $this->app->afterResolving(Kernel::class, $push);
+
+        if ($this->app->resolved(Kernel::class)) {
+            $push($this->app->make(Kernel::class));
+        }
     }
 
     /**

--- a/tests/Feature/InertiaTest.php
+++ b/tests/Feature/InertiaTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Inertia\Ssr\DisablesSsr;
@@ -13,6 +14,14 @@ use Inertia\Support\Header;
 use Laravel\Head\Facades\Head;
 use Laravel\Head\HeadBuilder;
 use Laravel\Head\HeadManager;
+use Laravel\Head\Inertia\ShareHead;
+use Laravel\Head\Tests\Fixtures\ResolvesHttpKernelEarly;
+
+uses(ResolvesHttpKernelEarly::class);
+
+it('registers the share head middleware when the http kernel was resolved before the package', function (): void {
+    expect($this->app->make(Kernel::class)->hasMiddleware(ShareHead::class))->toBeTrue();
+});
 
 it('shares rendered head elements with inertia page objects', function (): void {
     Head::defaults(fn (HeadBuilder $head) => $head->title('Acme', suffix: ' - Acme'));

--- a/tests/Fixtures/ResolvesHttpKernelEarly.php
+++ b/tests/Fixtures/ResolvesHttpKernelEarly.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Tests\Fixtures;
+
+use Illuminate\Contracts\Http\Kernel;
+
+/**
+ * Resolves the HTTP kernel before service providers are registered, mirroring
+ * Application::handleRequest(), which resolves the kernel and then bootstraps
+ * the application while handling the request.
+ */
+trait ResolvesHttpKernelEarly
+{
+    protected function resolveApplicationHttpKernel($app): void
+    {
+        parent::resolveApplicationHttpKernel($app);
+
+        $app->make(Kernel::class);
+    }
+}


### PR DESCRIPTION
`Application::handleRequest()` resolves the HTTP kernel before bootstrapping the app, so the `afterResolving(Kernel::class)` hook added in #9 never fires under a standard request.

This PR pushes the middleware onto an already resolved kernel while retaining the hook for Octane. The tests have also been updated to resolve the kernel early to match the `handleRequest()` behavior.