### PR TITLE
Add event schema

### DIFF
--- a/src/Facades/Schema.php
+++ b/src/Facades/Schema.php
@@ -19,6 +19,7 @@ use Laravel\Head\Schema\SchemaFactory;
  * @method static \Laravel\Head\Schema\Person person()
  * @method static \Laravel\Head\Schema\WebPage webPage()
  * @method static \Laravel\Head\Schema\WebSite webSite()
+ * @method static \Laravel\Head\Schema\Event event()
  * @method static ($type is class-string<TSchema> ? TSchema : \Laravel\Head\Schema\SchemaObject) make<TSchema of \Laravel\Head\Schema\SchemaObject>(class-string<TSchema>|string $type)
  * @method static \Laravel\Head\Schema\SchemaFactory register(string $class)
  *

--- a/src/Schema/Event.php
+++ b/src/Schema/Event.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Schema;
+
+use DateTimeInterface;
+use Laravel\Head\SchemaType;
+
+#[SchemaType('Event')]
+class Event extends SchemaObject
+{
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    public function doorTime(DateTimeInterface|string $doorTime): static
+    {
+        return $this->date('doorTime', $doorTime);
+    }
+
+    public function endDate(DateTimeInterface|string $endDate): static
+    {
+        return $this->date('endDate', $endDate);
+    }
+
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /**
+     * @param  Offer|array<int, Offer>  $offers
+     */
+    public function offers(Offer|array $offers): static
+    {
+        return $this->set('offers', $offers);
+    }
+
+    public function organizer(Organization|Person $organizer): static
+    {
+        return $this->set('organizer', $organizer);
+    }
+
+    public function startDate(DateTimeInterface|string $startDate): static
+    {
+        return $this->date('startDate', $startDate);
+    }
+}

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -25,6 +25,7 @@ class SchemaFactory
         $this->register(Person::class);
         $this->register(WebPage::class);
         $this->register(WebSite::class);
+        $this->register(Event::class);
     }
 
     /**


### PR DESCRIPTION
Adds a new `Event` schema.

Appreciate the team may not want to create PHP classes for each and every schema documented on schema.org, but feel `Event` is generic and commonplace enough to warrant its own class, and was surprised to see it wasn’t already included.