### PR TITLE
Add location, image, performer, status etc to Event schema

### DIFF
--- a/src/Enums/EventAttendanceMode.php
+++ b/src/Enums/EventAttendanceMode.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Enums;
+
+enum EventAttendanceMode: string
+{
+    case Mixed = 'MixedEventAttendanceMode';
+    case Offline = 'OfflineEventAttendanceMode';
+    case Online = 'OnlineEventAttendanceMode';
+
+    public function url(): string
+    {
+        return 'https://schema.org/'.$this->value;
+    }
+}

--- a/src/Enums/EventStatus.php
+++ b/src/Enums/EventStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Enums;
+
+enum EventStatus: string
+{
+    case Cancelled = 'EventCancelled';
+    case MovedOnline = 'EventMovedOnline';
+    case Postponed = 'EventPostponed';
+    case Rescheduled = 'EventRescheduled';
+    case Scheduled = 'EventScheduled';
+
+    public function url(): string
+    {
+        return 'https://schema.org/'.$this->value;
+    }
+}

--- a/src/Schema/Event.php
+++ b/src/Schema/Event.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Laravel\Head\Schema;
 
 use DateTimeInterface;
+use Laravel\Head\Enums\EventAttendanceMode;
+use Laravel\Head\Enums\EventStatus;
 use Laravel\Head\SchemaType;
 
 #[SchemaType('Event')]
@@ -25,6 +27,32 @@ class Event extends SchemaObject
         return $this->date('endDate', $endDate);
     }
 
+    public function eventAttendanceMode(EventAttendanceMode $mode): static
+    {
+        return $this->set('eventAttendanceMode', $mode->url());
+    }
+
+    public function eventStatus(EventStatus $status): static
+    {
+        return $this->set('eventStatus', $status->url());
+    }
+
+    /**
+     * @param  string|array<int, string>  $image
+     */
+    public function image(string|array $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /**
+     * Set the event location. A string is treated as the name of a physical place.
+     */
+    public function location(SchemaObject|string $location): static
+    {
+        return $this->set('location', is_string($location) ? (new Place)->name($location) : $location);
+    }
+
     public function name(string $name): static
     {
         return $this->set('name', $name);
@@ -41,6 +69,14 @@ class Event extends SchemaObject
     public function organizer(Organization|Person $organizer): static
     {
         return $this->set('organizer', $organizer);
+    }
+
+    /**
+     * @param  Organization|Person|array<int, Organization|Person>  $performer
+     */
+    public function performer(Organization|Person|array $performer): static
+    {
+        return $this->set('performer', $performer);
     }
 
     public function startDate(DateTimeInterface|string $startDate): static

--- a/src/Schema/Place.php
+++ b/src/Schema/Place.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Head\Schema;
+
+use Laravel\Head\SchemaType;
+
+#[SchemaType('Place')]
+class Place extends SchemaObject
+{
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /**
+     * @param  SchemaObject|array<string, mixed>|string  $address
+     */
+    public function address(SchemaObject|array|string $address): static
+    {
+        return $this->set('address', $address);
+    }
+
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+}

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -26,6 +26,7 @@ class SchemaFactory
         $this->register(Person::class);
         $this->register(WebPage::class);
         $this->register(WebSite::class);
+        $this->register(Place::class);
     }
 
     /**

--- a/tests/Feature/Schema/EventSchemaTest.php
+++ b/tests/Feature/Schema/EventSchemaTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Head\Enums\EventAttendanceMode;
+use Laravel\Head\Enums\EventStatus;
+use Laravel\Head\Enums\OfferAvailability;
+use Laravel\Head\Facades\Head;
+use Laravel\Head\Facades\Schema;
+use Laravel\Head\Schema\Place;
+
+it('renders an event with the properties required for rich results', function (): void {
+    Head::schema(
+        Schema::event()
+            ->name('Laracon US')
+            ->startDate('2026-08-20T09:00:00-05:00')
+            ->endDate(new DateTimeImmutable('2026-08-21T17:00:00-05:00'))
+            ->location(
+                Schema::place()
+                    ->name('Music City Center')
+                    ->address('201 Rep. John Lewis Way S, Nashville, TN')
+            )
+    );
+
+    expect(Head::toHtml())
+        ->toContain('"@type":"Event"')
+        ->toContain('"name":"Laracon US"')
+        ->toContain('"startDate":"2026-08-20T09:00:00-05:00"')
+        ->toContain('"endDate":"2026-08-21T17:00:00-05:00"')
+        ->toContain('"location":{"@type":"Place","name":"Music City Center","address":"201 Rep. John Lewis Way S, Nashville, TN"}');
+});
+
+it('treats a string location as the name of a place', function (): void {
+    $event = Schema::event()->location('Music City Center');
+
+    expect($event->toArray()['location'])->toBe(['@type' => 'Place', 'name' => 'Music City Center']);
+});
+
+it('sets event status and attendance mode from schema org enum values', function (): void {
+    $event = Schema::event()
+        ->eventStatus(EventStatus::Scheduled)
+        ->eventAttendanceMode(EventAttendanceMode::Offline);
+
+    expect($event->toArray())
+        ->toMatchArray([
+            'eventStatus' => 'https://schema.org/EventScheduled',
+            'eventAttendanceMode' => 'https://schema.org/OfflineEventAttendanceMode',
+        ]);
+});
+
+it('sets event images, performers, organizer and offers', function (): void {
+    $event = Schema::event()
+        ->image(['https://example.com/hero.jpg', 'https://example.com/stage.jpg'])
+        ->performer([Schema::person()->name('Taylor Otwell'), Schema::organization()->name('Laravel')])
+        ->organizer(Schema::organization()->name('Laravel'))
+        ->offers(
+            Schema::offer()
+                ->price(499)
+                ->currency('USD')
+                ->availability(OfferAvailability::InStock)
+        );
+
+    expect($event->toArray())
+        ->toMatchArray([
+            'image' => ['https://example.com/hero.jpg', 'https://example.com/stage.jpg'],
+            'performer' => [
+                ['@type' => 'Person', 'name' => 'Taylor Otwell'],
+                ['@type' => 'Organization', 'name' => 'Laravel'],
+            ],
+            'organizer' => ['@type' => 'Organization', 'name' => 'Laravel'],
+        ])
+        ->and($event->toArray()['offers'])->toMatchArray(['@type' => 'Offer', 'price' => 499, 'priceCurrency' => 'USD']);
+});
+
+it('registers place as a first class factory method', function (): void {
+    expect(Schema::place())->toBeInstanceOf(Place::class)
+        ->and(Schema::place()->name('Venue')->url('https://example.com/venue')->toArray())
+        ->toBe(['@type' => 'Place', 'name' => 'Venue', 'url' => 'https://example.com/venue']);
+});
+
+it('includes all schema org event status and attendance mode values', function (): void {
+    expect(EventStatus::Cancelled->url())->toBe('https://schema.org/EventCancelled')
+        ->and(EventStatus::MovedOnline->url())->toBe('https://schema.org/EventMovedOnline')
+        ->and(EventAttendanceMode::Mixed->url())->toBe('https://schema.org/MixedEventAttendanceMode');
+});


### PR DESCRIPTION
## Problem

The `Event` schema added in #13 exposes `name`, `description`, `startDate`, `endDate`, `doorTime`, `offers` and `organizer`, but not `location`. [Google's Event structured-data guidelines](https://developers.google.com/search/docs/appearance/structured-data/event) list location as a required property alongside `name` and `startDate` (items missing a required property are [not eligible for rich results](https://developers.google.com/search/docs/appearance/structured-data/sd-policies)), and it's a core property of the [schema.org Event](https://schema.org/Event) type. As shipped, the typed builder can't produce a rich-result-eligible Event without falling back to the untyped `set()`.

It also lacks the recommended `image`, `performer`, `eventStatus` and `eventAttendanceMode` properties, while `Product` and `Article` already expose `image()`.

## Change

`Laravel\Head\Schema\Event` gains:

- `location(SchemaObject|string $location)` accepts a schema object (normally a `Place`), or a plain string which is treated as the venue name and wrapped in a `Place`.
- `image(string|array $image)` same shape as `Product::image()`.
- `performer(Organization|Person|array $performer)` single or list, same shape as `offers()`.
- `eventStatus(EventStatus $status)` and `eventAttendanceMode(EventAttendanceMode $mode)` new backed enums following the `OfferAvailability` pattern, rendered as `https://schema.org/...` URLs.

New `Laravel\Head\Schema\Place` (`name`, `address`, `url`) is registered in `SchemaFactory` and the `Schema` facade docblock, so `Schema::place()` works like every other built-in type.

## Example

```php
Head::schema(
    Schema::event()
        ->name('Laracon US')
        ->startDate($event->starts_at)
        ->endDate($event->ends_at)
        ->location(Schema::place()->name('City Center')->address('Nashville, TN'))
        ->image($event->hero_image_url)
        ->eventStatus(EventStatus::Scheduled)
        ->eventAttendanceMode(EventAttendanceMode::Offline)
        ->offers(Schema::offer()->price(499)->currency('USD')->availability(OfferAvailability::InStock))
);
```

## Tests

`tests/Feature/Schema/EventSchemaTest.php` (the Event schema previously had no tests):

- renders a full Event with `Place` location through `Head::toHtml()`
- string location becomes `{"@type":"Place","name":"..."}`
- status / attendance-mode enums render as schema.org URLs
- image list, performer list, organizer and offers coerce correctly
- `Schema::place()` is a first-class factory method
- enum `url()` coverage